### PR TITLE
Draft: Change find key behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ users_dict = {
 }
 DDB.at("users").create(user_data_dict)
 ```
-There is now a file called `users.json` or `users.ddb` in your specified storage 
+There is now a file called `users.json` or `users.ddb` in your specified storage
 directory depending on if you use compression.
 
 
@@ -104,9 +104,9 @@ Check if file or sub-key exists
 ```python
 DDB.at("users").exists()
 >>> True  # File exists
-DDB.at("users", key="u10").exists() 
->>> False # Key "u10" not in users 
-DDB.at("users", key="u2").exists() 
+DDB.at("users", key="u10").exists()
+>>> False # Key "u10" not in users
+DDB.at("users", key="u2").exists()
 >>> True
 ```
 
@@ -122,9 +122,9 @@ joe = DDB.at("users", key="u3").read()
 joe == users_dict["Joe"] # True
 ```
 
-> Note: Doing a partial read like with `DDB.at("users", key="Joe").read()` will return
-> the value of the key at the outermost indentation level if the key appears in the
-> file multiple times.
+> Note: Doing a partial read like with `DDB.at("users", key="Joe").read()` will only
+> return the value of the key if the key is at the root indentation level.
+> Example: You can get "a" from {"a" : 3}, but not from {"b": {"a": 3}}.
 
 It is also possible to only read a subset of keys based on a filter callback:
 
@@ -255,8 +255,8 @@ API Reference
 ### `at(path) -> DDBMethodChooser:`
 Select a file or folder to perform an operation on.
 If you want to select a specific key in a file, use the `key` parameter,
-e.g. `DDB.at("file", key="subkey")`. If the key appears multiple times in the file,
-the value of the key at the outermost indentation level will be returned.
+e.g. `DDB.at("file", key="subkey")`. The key value is only returned if the key
+is at the root level of the json object.
 
 If you want to select an entire folder, use the `*` wildcard,
 eg. `DDB.at("folder", "*")`, or `DDB.at("folder/*")`. You can also use

--- a/dictdatabase/utils.py
+++ b/dictdatabase/utils.py
@@ -138,7 +138,7 @@ def find_outermost_key_in_json_bytes(json_bytes: bytes, key: str) -> Tuple[int, 
 	"""
 
 	# TODO: Very strict. the key must have a colon directly after it
-	# For example {"a": 1} will work, but {"a" : 1} will not work
+	# For example {"a": 1} will work, but {"a" : 1} will not work!
 
 	key = f"\"{key}\":".encode()
 

--- a/dictdatabase/utils.py
+++ b/dictdatabase/utils.py
@@ -82,17 +82,15 @@ def seek_index_through_value_bytes(json_bytes: bytes, index: int) -> int:
 		elif current == byte_codes.OPEN_CURLY:
 			dict_depth += 1
 		# Handle closing brackets
-		elif current in [byte_codes.CLOSE_SQUARE, byte_codes.CLOSE_CURLY]:
-			if current == byte_codes.CLOSE_SQUARE:
-				list_depth -= 1
-			if current == byte_codes.CLOSE_CURLY:
-				dict_depth -= 1
-			if list_depth == 0:
-				if dict_depth == 0:
-					return i + 1
-				if dict_depth == -1:
-					return i  # Case: {"a": {}}
-		elif list_depth == 0 and ((dict_depth == 0 and current in [byte_codes.COMMA, byte_codes.NEWLINE]) or dict_depth == -1):
+		elif current == byte_codes.CLOSE_SQUARE:
+			list_depth -= 1
+			if list_depth == 0 and dict_depth <= 0:
+				return i + 1 + dict_depth  # dict_depth is -1 in case: {"a": {}}
+		elif current == byte_codes.CLOSE_CURLY:
+			dict_depth -= 1
+			if dict_depth <= 0 and list_depth == 0:
+				return i + 1 + dict_depth  # dict_depth is -1 in case: {"a": {}}
+		elif list_depth == 0 and ((dict_depth == 0 and (current == byte_codes.COMMA or current == byte_codes.NEWLINE)) or dict_depth == -1):
 			# Handle commas and newline as exit points
 			return i
 		i += 1

--- a/dictdatabase/utils.py
+++ b/dictdatabase/utils.py
@@ -105,20 +105,18 @@ def count_nesting_in_bytes(json_bytes: bytes, start: int, end: int) -> int:
 	- `json_bytes`: A bytes object containing valid JSON when decoded
 	"""
 
-	in_str, nesting, i = False, 0, start
-	while i < end:
-		byte_i = json_bytes[i]
-		if byte_i == byte_codes.BACKSLASH:
-			i += 1
-		elif byte_i == byte_codes.QUOTE:
-			in_str = not in_str
-		elif in_str:
-			pass
-		elif byte_i == byte_codes.OPEN_CURLY:
+	nesting, i, j = 0, start, start
+
+	while (i := json_bytes.find(byte_codes.OPEN_CURLY, i, end)) != -1:
+		if i == 0 or json_bytes[i - 1] != byte_codes.BACKSLASH:
 			nesting += 1
-		elif byte_i == byte_codes.CLOSE_CURLY:
-			nesting -= 1
 		i += 1
+
+	while (j := json_bytes.find(byte_codes.CLOSE_CURLY, j, end)) != -1:
+		if j == 0 or json_bytes[j - 1] != byte_codes.BACKSLASH:
+			nesting -= 1
+		j += 1
+
 	return nesting
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,5 @@ ignore = [
 	"ANN101", # missing type annotation for self
 	"E501", # line length
 	"UP007", # use X | Y for union (not possible in python 3.8)
+    "UP006", # Use typing.Tuple for python 3.8 support
 ]

--- a/test_key_finder.py
+++ b/test_key_finder.py
@@ -1,0 +1,26 @@
+import json
+
+from dictdatabase import utils
+
+test_dict = {
+    "b": 2,
+    "c": {
+        "a": 1,
+        "b": 2,
+    },
+    "d": {
+        "a": 1,
+        "b": 2,
+    },
+    "a": 1,
+
+}
+
+json_str = json.dumps(test_dict, indent=2, sort_keys=False)
+json_bytes = json_str.encode()
+
+index = utils.find_outermost_key_in_json_bytes(json_bytes, "a")
+
+print("lel")
+print(index)
+print(json_bytes[index[0]:index[1]])

--- a/test_key_finder.py
+++ b/test_key_finder.py
@@ -24,3 +24,7 @@ index = utils.find_outermost_key_in_json_bytes(json_bytes, "a")
 print("lel")
 print(index)
 print(json_bytes[index[0]:index[1]])
+
+
+
+print(b"00111000".find(b"111", 0, 20))

--- a/tests/test_indentation.py
+++ b/tests/test_indentation.py
@@ -4,6 +4,8 @@ import orjson
 import json
 from dictdatabase import utils, io_unsafe, config, io_bytes
 
+import pytest
+
 data = {
 	'a': 1,
 	'b': {
@@ -37,8 +39,8 @@ def test_indentation(use_test_dir, use_compression, use_orjson, indent):
 
 	assert io_bytes.read("test_indentation") == string_dump(data)
 
-	with DDB.at("test_indentation", key="d").session() as (session, db_d):
-		db_d["e"] = 4
-		session.write()
-	data["b"]["d"]["e"] = 4
+	# Accessing a key not at root level should raise an error
+	with pytest.raises(KeyError):
+		with DDB.at("test_indentation", key="d").session() as (session, db_d):
+			session.write()
 	assert io_bytes.read("test_indentation") == string_dump(data)

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -50,7 +50,8 @@ def test_subwrite(use_test_dir, use_compression, use_orjson, indent):
 	with DDB.at(name, key="b").session(as_type=pd) as (session, task):
 		task["f"] = lambda x: (x or 0) + 2
 		session.write()
-	assert DDB.at(name, key="f").read() == 2
+
+	assert DDB.at(name, key="f").read() is None
 
 	with pytest.raises(KeyError):
 		with DDB.at(name, key="none").session() as (session, key):


### PR DESCRIPTION
The key finder returns the outermost key, but that can also be a nested key. With this change, only root level keys are considered