### PR TITLE
tests: use `tmp_path` fixture to isolate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ddb_storage
 test_db/
 *.prof
 dist/
+__pycache__

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-TEST_DIR = "./.ddb_pytest_storage"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,11 @@
+from pathlib import Path
 import dictdatabase as DDB
-from tests import TEST_DIR
 import pytest
-import shutil
-import os
 
 
-@pytest.fixture(scope="session")
-def use_test_dir(request):
-	DDB.config.storage_directory = TEST_DIR
-	os.makedirs(TEST_DIR, exist_ok=True)
-	request.addfinalizer(lambda: shutil.rmtree(TEST_DIR))
+@pytest.fixture(autouse=True)
+def isolate_database_files(tmp_path: Path):
+	DDB.config.storage_directory = str(tmp_path)
 
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -6,7 +6,7 @@ import json
 from tests.utils import make_complex_nested_random_dict
 
 
-def test_create(use_test_dir, use_compression, use_orjson, indent):
+def test_create(use_compression, use_orjson, indent):
 	DDB.at("create").create(force_overwrite=True)
 	db = DDB.at("create").read()
 	assert db == {}
@@ -23,7 +23,7 @@ def test_create(use_test_dir, use_compression, use_orjson, indent):
 		DDB.at("create", key="any").create(force_overwrite=True)
 
 
-def test_create_edge_cases(use_test_dir, use_compression, use_orjson, indent):
+def test_create_edge_cases(use_compression, use_orjson, indent):
 	cases = [-2, 0.0, "", "x", [], {}, True]
 
 	for i, c in enumerate(cases):
@@ -34,7 +34,7 @@ def test_create_edge_cases(use_test_dir, use_compression, use_orjson, indent):
 		DDB.at("tcec99").create(object(), force_overwrite=True)
 
 
-def test_nested_file_creation(use_test_dir, use_compression, use_orjson, indent):
+def test_nested_file_creation(use_compression, use_orjson, indent):
 	n = DDB.at("nested/file/nonexistent").read()
 	assert n is None
 	db = make_complex_nested_random_dict(12, 6)
@@ -42,7 +42,7 @@ def test_nested_file_creation(use_test_dir, use_compression, use_orjson, indent)
 	assert DDB.at("nested/file/creation/test").read() == db
 
 
-def test_create_same_file_twice(use_test_dir, use_compression, use_orjson, indent):
+def test_create_same_file_twice(use_compression, use_orjson, indent):
 	name = "test_create_same_file_twice"
 	# Check that creating the same file twice must raise an error
 	with pytest.raises(FileExistsError):

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -2,7 +2,7 @@ import dictdatabase as DDB
 import pytest
 
 
-def test_delete(use_test_dir, use_compression, use_orjson, indent):
+def test_delete(use_compression, use_orjson, indent):
 	DDB.at("test_delete").create({"a": 1}, force_overwrite=True)
 	assert DDB.at("test_delete").read() == {"a": 1}
 	DDB.at("test_delete").delete()
@@ -16,5 +16,5 @@ def test_delete(use_test_dir, use_compression, use_orjson, indent):
 
 
 
-def test_delete_nonexistent(use_test_dir, use_compression, use_orjson, indent):
+def test_delete_nonexistent(use_compression, use_orjson, indent):
 	DDB.at("test_delete_nonexistent").delete()

--- a/tests/test_excepts.py
+++ b/tests/test_excepts.py
@@ -4,7 +4,7 @@ from path_dict import pd
 import pytest
 
 
-def test_except_during_open_session(use_test_dir, use_compression, use_orjson, indent):
+def test_except_during_open_session(use_compression, use_orjson, indent):
 	name = "test_except_during_open_session"
 	d = {"test": "value"}
 	DDB.at(name).create(d, force_overwrite=True)
@@ -14,7 +14,7 @@ def test_except_during_open_session(use_test_dir, use_compression, use_orjson, i
 
 
 
-def test_except_on_save_unserializable(use_test_dir, use_compression, use_orjson, indent):
+def test_except_on_save_unserializable(use_compression, use_orjson, indent):
 	name = "test_except_on_save_unserializable"
 	with pytest.raises(TypeError):
 		d = {"test": "value"}
@@ -24,7 +24,7 @@ def test_except_on_save_unserializable(use_test_dir, use_compression, use_orjson
 			session.write()
 
 
-def test_except_on_save_unserializable_in_multisession(use_test_dir, use_compression, use_orjson, indent):
+def test_except_on_save_unserializable_in_multisession(use_compression, use_orjson, indent):
 	name = "test_except_on_save_unserializable_in_multisession"
 	with pytest.raises(TypeError):
 		d = {"test": "value"}
@@ -35,7 +35,7 @@ def test_except_on_save_unserializable_in_multisession(use_test_dir, use_compres
 			session.write()
 
 
-def test_except_on_session_in_session(use_test_dir, use_compression, use_orjson, indent):
+def test_except_on_session_in_session(use_compression, use_orjson, indent):
 	name = "test_except_on_session_in_session"
 	d = {"test": "value"}
 	DDB.at(name).create(d, force_overwrite=True)
@@ -45,24 +45,24 @@ def test_except_on_session_in_session(use_test_dir, use_compression, use_orjson,
 				pass
 
 
-def test_except_on_write_outside_session(use_test_dir, use_compression, use_orjson, indent):
+def test_except_on_write_outside_session(use_compression, use_orjson, indent):
 	with pytest.raises(PermissionError):
 		s = DDB.at("test_except_on_write_outside_session").session()
 		s.write()
 
 
-def test_wildcard_and_subkey_except(use_test_dir, use_compression, use_orjson, indent):
+def test_wildcard_and_subkey_except(use_compression, use_orjson, indent):
 	with pytest.raises(TypeError):
 		DDB.at("test_wildcard_and_subkey_except/*", key="key").read()
 
 
 
-def test_utils_invalid_json_except(use_test_dir):
+def test_utils_invalid_json_except():
 	with pytest.raises(TypeError):
 		utils.seek_index_through_value_bytes(b"{This is not { JSON", 0)
 
 
-def test_bytes_write_except(use_test_dir):
+def test_bytes_write_except():
 	# It is not allowed to specify a start index when compression is used.
 	with pytest.raises(RuntimeError):
 		DDB.config.use_compression = True

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -2,7 +2,7 @@ import dictdatabase as DDB
 import pytest
 
 
-def test_exists(use_test_dir, use_compression, use_orjson, indent):
+def test_exists(use_compression, use_orjson, indent):
 	DDB.at("test_exists").create({"a": 1}, force_overwrite=True)
 	assert DDB.at("test_exists").exists()
 	assert not DDB.at("test_exists/nonexistent").exists()

--- a/tests/test_indentation.py
+++ b/tests/test_indentation.py
@@ -29,7 +29,7 @@ def string_dump(db: dict):
 
 
 
-def test_indentation(use_test_dir, use_compression, use_orjson, indent):
+def test_indentation(use_compression, use_orjson, indent):
 	DDB.at("test_indentation").create(data, force_overwrite=True)
 
 	with DDB.at("test_indentation", key="b").session() as (session, db_b):

--- a/tests/test_io_bytes.py
+++ b/tests/test_io_bytes.py
@@ -3,7 +3,7 @@ import pytest
 
 
 
-def test_write_bytes(use_test_dir, name_of_test, use_compression):
+def test_write_bytes(name_of_test, use_compression):
     # No partial writing to compressed file allowed
     if use_compression:
         with pytest.raises(RuntimeError):
@@ -27,7 +27,7 @@ def test_write_bytes(use_test_dir, name_of_test, use_compression):
 
 
 
-def test_read_bytes(use_test_dir, name_of_test, use_compression):
+def test_read_bytes(name_of_test, use_compression):
     io_bytes.write(name_of_test, b"0123456789")
     # In range
     assert io_bytes.read(name_of_test, start=2, end=5) == b"234"

--- a/tests/test_io_safe.py
+++ b/tests/test_io_safe.py
@@ -4,7 +4,7 @@ import pytest
 import json
 
 
-def test_read(use_test_dir, use_compression, use_orjson, indent):
+def test_read(use_compression, use_orjson, indent):
     # Elicit read error
     DDB.config.use_orjson = True
     with pytest.raises(json.decoder.JSONDecodeError):
@@ -13,16 +13,16 @@ def test_read(use_test_dir, use_compression, use_orjson, indent):
         io_safe.read("corrupted_json")
 
 
-def test_partial_read(use_test_dir, use_compression, use_orjson, indent):
+def test_partial_read(use_compression, use_orjson, indent):
     assert io_safe.partial_read("nonexistent", key="none") is None
 
 
-def test_write(use_test_dir, use_compression, use_orjson, indent):
+def test_write(use_compression, use_orjson, indent):
     with pytest.raises(TypeError):
         io_safe.write("nonexistent", lambda x: x)
 
 
-def test_delete(use_test_dir, use_compression, use_orjson, indent):
+def test_delete(use_compression, use_orjson, indent):
     DDB.at("to_be_deleted").create()
     DDB.at("to_be_deleted").delete()
     assert DDB.at("to_be_deleted").read() is None

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -2,10 +2,9 @@ from dictdatabase import locking
 import pytest
 import threading
 import time
-from tests import TEST_DIR
 
 
-def test_double_lock_exception(use_test_dir, use_compression):
+def test_double_lock_exception(use_compression):
 	name = "test_double_lock_exception"
 	with pytest.raises(RuntimeError):
 		with locking.ReadLock(name):
@@ -16,7 +15,7 @@ def test_double_lock_exception(use_test_dir, use_compression):
 	assert len(ls.locks) == 0
 
 
-def test_get_lock_names(use_test_dir, use_compression):
+def test_get_lock_names(use_compression):
 	lock = locking.ReadLock("db")
 	lock._lock()
 
@@ -40,7 +39,7 @@ def test_get_lock_names(use_test_dir, use_compression):
 
 
 
-def test_remove_orphaned_locks(use_test_dir):
+def test_remove_orphaned_locks():
 	prev_config = locking.LOCK_TIMEOUT
 	locking.LOCK_TIMEOUT = 0.1
 	lock = locking.ReadLock("test_remove_orphaned_locks")
@@ -57,7 +56,7 @@ def test_remove_orphaned_locks(use_test_dir):
 	locking.LOCK_TIMEOUT = prev_config
 
 
-def test_AbstractLock(use_test_dir):
+def test_AbstractLock():
 	l = locking.AbstractLock("test_AbstractLock")
 	with pytest.raises(NotImplementedError):
 		l._lock()

--- a/tests/test_parallel_sessions.py
+++ b/tests/test_parallel_sessions.py
@@ -27,7 +27,7 @@ def read_counters(n, tables, cfg):
 	return True
 
 
-def test_stress_multiprocessing(use_test_dir, use_compression, use_orjson):
+def test_stress_multiprocessing(use_compression, use_orjson):
 	per_thread = 15
 	tables = 1
 	threads = 3
@@ -65,7 +65,7 @@ def read_partial(n, cfg):
 	return True
 
 
-def test_induce_indexer_except(use_test_dir, use_compression):
+def test_induce_indexer_except(use_compression):
 	DDB.at("test_stress_parallel0").create({}, force_overwrite=True)
 
 	pool = Pool(processes=2)

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -4,7 +4,7 @@ import json
 import pytest
 
 
-def test_subread(use_test_dir, use_compression, use_orjson, indent):
+def test_subread(use_compression, use_orjson, indent):
 	name = "test_subread"
 	j = {
 		"a": "Hello{}",
@@ -34,7 +34,7 @@ def test_subread(use_test_dir, use_compression, use_orjson, indent):
 	assert DDB.at("test_subread3", key="a").read() == {"b": {"\\c\\": {"a": "a"}}}
 
 
-def test_subwrite(use_test_dir, use_compression, use_orjson, indent):
+def test_subwrite(use_compression, use_orjson, indent):
 	name = "test_subwrite"
 	j = {
 		"b": {"0": 1},
@@ -58,7 +58,7 @@ def test_subwrite(use_test_dir, use_compression, use_orjson, indent):
 			session.write()
 
 
-def test_write_file_where(use_test_dir, use_compression, use_orjson, indent):
+def test_write_file_where(use_compression, use_orjson, indent):
 	name = "test_write_file_where"
 	j = {
 		"a": 1,
@@ -81,7 +81,7 @@ def test_write_file_where(use_test_dir, use_compression, use_orjson, indent):
 	}
 
 
-def test_dir_where(use_test_dir, use_compression, use_orjson, indent):
+def test_dir_where(use_compression, use_orjson, indent):
 	name = "test_dir_where"
 	for i in range(5):
 		DDB.at(name, i).create({"k": i}, force_overwrite=True)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -5,12 +5,12 @@ import json
 from tests.utils import make_complex_nested_random_dict
 
 
-def test_non_existent(use_test_dir, use_compression, use_orjson, indent):
+def test_non_existent(use_compression, use_orjson, indent):
 	d = DDB.at("nonexistent").read()
 	assert d is None
 
 
-def test_file_exists_error(use_test_dir, use_compression, use_orjson, indent):
+def test_file_exists_error(use_compression, use_orjson, indent):
 	with open(f"{DDB.config.storage_directory}/test_file_exists_error.json", "w") as f:
 		f.write("")
 	with open(f"{DDB.config.storage_directory}/test_file_exists_error.ddb", "w") as f:
@@ -19,7 +19,7 @@ def test_file_exists_error(use_test_dir, use_compression, use_orjson, indent):
 		DDB.at("test_file_exists_error").read()
 
 
-def test_invalid_params(use_test_dir, use_compression, use_orjson, indent):
+def test_invalid_params(use_compression, use_orjson, indent):
 	with pytest.raises(TypeError):
 		DDB.at("test_invalid_params", key="any", where=lambda k, v: True).read()
 
@@ -28,7 +28,7 @@ def test_invalid_params(use_test_dir, use_compression, use_orjson, indent):
 
 
 
-def test_read_integrity(use_test_dir, use_compression, use_orjson, indent):
+def test_read_integrity(use_compression, use_orjson, indent):
 	cases = [
 		r'{"a": "\\", "b": 0}',
 		r'{"a": "\\\\", "b": 1234}',
@@ -56,7 +56,7 @@ def test_read_integrity(use_test_dir, use_compression, use_orjson, indent):
 
 
 
-def test_create_and_read(use_test_dir, use_compression, use_orjson, indent):
+def test_create_and_read(use_compression, use_orjson, indent):
 	name = "test_create_and_read"
 	d = make_complex_nested_random_dict(12, 6)
 	DDB.at(name).create(d, force_overwrite=True)
@@ -64,7 +64,7 @@ def test_create_and_read(use_test_dir, use_compression, use_orjson, indent):
 	assert d == dd
 
 
-def test_read_compression_switching(use_test_dir, use_orjson, indent):
+def test_read_compression_switching(use_orjson, indent):
 	name = "test_read_compression_switching"
 	DDB.config.use_compression = False
 	d = make_complex_nested_random_dict(12, 6)
@@ -78,7 +78,7 @@ def test_read_compression_switching(use_test_dir, use_orjson, indent):
 	assert d == dd
 
 
-def test_multiread(use_test_dir, use_compression, use_orjson, indent):
+def test_multiread(use_compression, use_orjson, indent):
 	dl = []
 	for i in range(3):
 		dl += [make_complex_nested_random_dict(12, 6)]

--- a/tests/test_threaded_sessions.py
+++ b/tests/test_threaded_sessions.py
@@ -20,7 +20,7 @@ def read_counters(n, tables):
 	return True
 
 
-def test_stress_threaded(use_test_dir, use_compression, use_orjson):
+def test_stress_threaded(use_compression, use_orjson):
 	per_thread = 15
 	tables = 1
 	threads = 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import orjson
 from dictdatabase import utils, byte_codes
 
 
-def test_seek_index_through_value_bytes(use_test_dir):
+def test_seek_index_through_value_bytes():
 	v = b'{"a": 1, "b": {}}'
 	assert utils.seek_index_through_value_bytes(v, 5) == 7
 	assert utils.seek_index_through_value_bytes(v, 6) == 7
@@ -16,7 +16,7 @@ def test_seek_index_through_value_bytes(use_test_dir):
 	assert utils.seek_index_through_value_bytes(n, 6) == 10
 
 
-def test_seek_index_through_value_bytes_2(use_test_dir):
+def test_seek_index_through_value_bytes_2():
 	def load_with_orjson(bytes, key):
 		return orjson.loads(bytes)[key]
 

--- a/tests/test_where.py
+++ b/tests/test_where.py
@@ -3,7 +3,7 @@ from path_dict import PathDict
 import pytest
 
 
-def test_where(use_test_dir, use_compression, use_orjson, indent):
+def test_where(use_compression, use_orjson, indent):
     for i in range(10):
         DDB.at("test_select", i).create({"a": i}, force_overwrite=True)
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -4,14 +4,14 @@ import pytest
 from tests.utils import make_complex_nested_random_dict
 
 
-def test_non_existent_session(use_test_dir, use_compression, use_orjson, indent):
+def test_non_existent_session(use_compression, use_orjson, indent):
 	name = "test_non_existent_session"
 	with pytest.raises(FileNotFoundError):
 		with DDB.at(name).session() as (session, d):
 			session.write()
 
 
-def test_write(use_test_dir, use_compression, use_orjson, indent):
+def test_write(use_compression, use_orjson, indent):
 	name = "test_write"
 	d = make_complex_nested_random_dict(12, 6)
 	DDB.at(name).create(d, force_overwrite=True)
@@ -20,7 +20,7 @@ def test_write(use_test_dir, use_compression, use_orjson, indent):
 		session.write()
 
 
-def test_write_compression_switching(use_test_dir, use_orjson, indent):
+def test_write_compression_switching(use_orjson, indent):
 	name = "test_write_compression_switching"
 	DDB.config.use_compression = False
 	d = make_complex_nested_random_dict(12, 6)
@@ -41,7 +41,7 @@ def test_write_compression_switching(use_test_dir, use_orjson, indent):
 	assert DDB.at(name).read() == d
 
 
-def test_multi_session(use_test_dir, use_compression, use_orjson, indent):
+def test_multi_session(use_compression, use_orjson, indent):
 	a = {"a": 1}
 	b = {"b": 2}
 
@@ -54,7 +54,7 @@ def test_multi_session(use_test_dir, use_compression, use_orjson, indent):
 	assert DDB.at("test_multi_session/*").read() == {"d1": a, "d2": b}
 
 
-def test_write_wildcard_key_except(use_test_dir, use_compression, use_orjson, indent):
+def test_write_wildcard_key_except(use_compression, use_orjson, indent):
 	with pytest.raises(TypeError):
 		with DDB.at("test/*", key="any").session() as (session, d):
 			pass


### PR DESCRIPTION
Lots of changes, but at the end it's a cleaner way to use a custom folder for each test. `pytest` will handle the auto-deletion of the temporary folder at the end of the test, no need to do it ourselves.

Going a step further, it is now useless to use `force_overwrite=True` when creating databases. But to ease the review, and eventual approval, I decided to not touch that part.