### PR TITLE
Feature: os_touch - Ensure that entire folder structure exists

### DIFF
--- a/dictdatabase/locking.py
+++ b/dictdatabase/locking.py
@@ -21,6 +21,7 @@ def os_touch(path: str) -> None:
 	"""
 	mode = 0o666
 	flags = os.O_CREAT | os.O_WRONLY | os.O_EXCL
+	os.makedirs(os.path.dirname(path), exist_ok=True)
 	fd = os.open(path, flags, mode)
 	os.close(fd)
 


### PR DESCRIPTION
This is done to avoid a crash when taking a ReadLock while reading a folder of objects.


I was experiencing a problem where I got the following error:

```
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\path\\to\\AppDirData\\1.0\\database\\.ddb\\projects\\9c25eb71-8be2-487f-8c18-a96c49416ecd.11232.1692961820740517700.need.read.lock'
```

when trying to do roughly the following:

```python
DDB.at("projects", project.id).create(
    project.model_dump(),
    force_overwrite=True,
)

res = DDB.at("projects", "*", where=...).read()
```

It seems that locking writes a lock file using `os_touch` and in case of folders, at least on Windows in my case, it fails if the parent folder (`projects`) is not present.

The solution seems to be to just create the folder structure. 